### PR TITLE
Don't return a 404 when a page is empty, but return an empty list

### DIFF
--- a/Controller/GenerateController.php
+++ b/Controller/GenerateController.php
@@ -33,10 +33,6 @@ class GenerateController extends AbstractController
     {
         $sitemapSectionPage = $this->getSitemapGenerator()->generateSectionPage($section, $page);
 
-        if ($sitemapSectionPage->getCount() === 0) {
-            return new Response('Requested page is out of range', Response::HTTP_NOT_FOUND);
-        }
-
         return $this->render('WerkspotSitemapBundle::section.xml.twig', [
             'sitemap_section' => $sitemapSectionPage
         ], $this->getEmptyXmlResponse());

--- a/Tests/Controller/GenerateControllerTest.php
+++ b/Tests/Controller/GenerateControllerTest.php
@@ -162,6 +162,7 @@ class GenerateControllerTest extends WebTestCase
 
         $mockSectionPage = Mockery::mock(SitemapSectionPage::class);
         $mockSectionPage->shouldReceive('getCount')->andReturn(0);
+        $mockSectionPage->shouldReceive('getUrls')->andReturn([]);
 
         $mockGenerator = Mockery::mock(Generator::class);
         $mockGenerator->shouldReceive('generateSectionPage')->andReturn($mockSectionPage);
@@ -169,6 +170,10 @@ class GenerateControllerTest extends WebTestCase
         $client->getContainer()->set('werkspot.sitemap.generator', $mockGenerator);
         $client->request('GET', $url);
 
-        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $xml = simplexml_load_string($client->getResponse()->getContent());
+        $this->assertEquals('urlset', $xml->getName());
+        $this->assertSame(0, $xml->count());
     }
 }


### PR DESCRIPTION
As it can happen that a page/list is (temporarily) empty, and we
don't want the crawlers to stop crawling that page