### PR TITLE
Add Symfony 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,13 @@ matrix:
     - php: 7.1
       env: SYMFONY_VERSION="^4.1"
     - php: 7.2
-      env: SYMFONY_VERSION="^4.1"
+      env: SYMFONY_VERSION="^4.2"
     - php: 7.3
-      env: SYMFONY_VERSION="^4.1"
+      env: SYMFONY_VERSION="^4.3"
     - php: 7.4
-      env: SYMFONY_VERSION="^4.1"
+      env: SYMFONY_VERSION="^4.4"
+    - php: 7.4
+      env: SYMFONY_VERSION="^5.1"
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,20 @@ language: php
 dist: trusty
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
 
 env:
   matrix:
-    - SYMFONY_VERSION="^4.1"
+    - SYMFONY_VERSION="^4.4"
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION="^4.1"
     - php: 7.2
-      env: SYMFONY_VERSION="^4.2"
-    - php: 7.3
-      env: SYMFONY_VERSION="^4.3"
-    - php: 7.4
-      env: SYMFONY_VERSION="^4.4"
+      env: SYMFONY_VERSION="^5.1"
     - php: 7.4
       env: SYMFONY_VERSION="^5.1"
 

--- a/Provider/AbstractSinglePageSitemapProvider.php
+++ b/Provider/AbstractSinglePageSitemapProvider.php
@@ -8,11 +8,7 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSectionPage;
  */
 abstract class AbstractSinglePageSitemapProvider extends AbstractSitemapProvider
 {
-    /**
-     * @param int $pageNumber
-     * @return SitemapSectionPage
-     */
-    final public function getPage($pageNumber)
+    final public function getPage(int $pageNumber): SitemapSectionPage
     {
         if ($pageNumber > 1) {
             return new SitemapSectionPage();
@@ -21,17 +17,12 @@ abstract class AbstractSinglePageSitemapProvider extends AbstractSitemapProvider
         return $this->getSinglePage();
     }
 
-    /**
-     * @return SitemapSectionPage
-     */
-    abstract public function getSinglePage();
+    abstract public function getSinglePage(): SitemapSectionPage;
 
     /**
      * Returning number of results just enough to indicate one page
-     *
-     * @return int
      */
-    final public function getCount()
+    final public function getCount(): int
     {
         return 1;
     }

--- a/Provider/AbstractSitemapProvider.php
+++ b/Provider/AbstractSitemapProvider.php
@@ -12,48 +12,30 @@ abstract class AbstractSitemapProvider implements ProviderInterface
      */
     protected $urlGenerator;
 
-    /**
-     * @param UrlGeneratorInterface $urlGenerator
-     */
     public function __construct(UrlGeneratorInterface $urlGenerator)
     {
         $this->urlGenerator = $urlGenerator;
     }
 
-    /**
-     * @return int
-     */
-    final public function getNumberOfPages()
+    final public function getNumberOfPages(): int
     {
         return ceil($this->getCount() / $this->getMaxItemsPerPage());
     }
 
-    /**
-     * @return SitemapSection
-     */
-    public function getSection()
+    public function getSection(): SitemapSection
     {
         return new SitemapSection($this->getSectionName());
     }
 
-    /**
-     * @param string $routeName
-     * @param array $options
-     * @return string
-     */
-    final protected function generateUrl($routeName, $options = [])
+    final protected function generateUrl(strintg $routeName, array $options = []): string
     {
         return $this->urlGenerator->generate($routeName, $options, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
      * Just to get consistent paging even with smaller limits
-     *
-     * @param array $data
-     * @param int $page
-     * @return array
      */
-    protected function getSimpleArrayPage(array $data, $page)
+    protected function getSimpleArrayPage(array $data, int $page): array
     {
         $limit = $this->getMaxItemsPerPage();
         $offset = ($page - 1) * $limit;
@@ -61,10 +43,7 @@ abstract class AbstractSitemapProvider implements ProviderInterface
         return array_slice($data, $offset, $limit);
     }
 
-    /**
-     * @return int
-     */
-    protected function getMaxItemsPerPage()
+    protected function getMaxItemsPerPage(): int
     {
         return SitemapSectionPage::MAX_ITEMS_PER_PAGE;
     }

--- a/Provider/ProviderInterface.php
+++ b/Provider/ProviderInterface.php
@@ -6,29 +6,9 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSectionPage;
 
 interface ProviderInterface
 {
-    /**
-     * @return SitemapSection
-     */
-    public function getSection();
-
-    /**
-     * @return string
-     */
-    public function getSectionName();
-
-    /**
-     * @return int
-     */
-    public function getNumberOfPages();
-
-    /**
-     * @return int
-     */
-    public function getCount();
-
-    /**
-     * @param int $pageNumber
-     * @return SitemapSectionPage
-     */
-    public function getPage($pageNumber);
+    public function getSection(): SitemapSection;
+    public function getSectionName(): string;
+    public function getNumberOfPages(): int;
+    public function getCount(): int;
+    public function getPage(int $pageNumber): SitemapSectionPage;
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,15 @@
 parameters:
-    werkspot.sitemap.cache.shared_max_age: 86400
+  werkspot.sitemap.cache.shared_max_age: 86400
 
 services:
-    werkspot.sitemap.generator:
-        class: Werkspot\Bundle\SitemapBundle\Service\Generator
-        public: true
+  _defaults:
+    autowire: true
+    public: true
+
+  werkspot.sitemap.generator:
+    class: Werkspot\Bundle\SitemapBundle\Service\Generator
+
+  Werkspot\Bundle\SitemapBundle\Controller\GenerateController:
+    arguments:
+      $cacheAge: '%werkspot.sitemap.cache.shared_max_age%'
+      $sitemapGenerator: '@werkspot.sitemap.generator'

--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -13,10 +13,7 @@ class Generator
      */
     private $providers = [];
 
-    /**
-     * @return SitemapIndex
-     */
-    public function generateIndex()
+    public function generateIndex(): SitemapIndex
     {
         $index = new SitemapIndex();
 
@@ -31,12 +28,7 @@ class Generator
         return $index;
     }
 
-    /**
-     * @param string $sectionName
-     * @param int $page
-     * @return SitemapSectionPage
-     */
-    public function generateSectionPage($sectionName, $page)
+    public function generateSectionPage(string $sectionName, int $page): SitemapSectionPage
     {
         $provider = $this->getProvider($sectionName);
 
@@ -47,19 +39,12 @@ class Generator
         return $provider->getPage($page);
     }
 
-    /**
-     * @param ProviderInterface $provider
-     */
-    public function addProvider(ProviderInterface $provider)
+    public function addProvider(ProviderInterface $provider): void
     {
         $this->providers[$provider->getSectionName()] = $provider;
     }
 
-    /**
-     * @param string $sectionName
-     * @return null|ProviderInterface
-     */
-    private function getProvider($sectionName)
+    private function getProvider(string $sectionName): ?ProviderInterface
     {
         return isset($this->providers[$sectionName]) ? $this->providers[$sectionName] : null;
     }

--- a/Sitemap/AlternateLink.php
+++ b/Sitemap/AlternateLink.php
@@ -17,28 +17,18 @@ class AlternateLink
      */
     private $hreflang;
 
-    /**
-     * @param string $href
-     * @param string $hreflang
-     */
-    public function __construct($href, $hreflang)
+    public function __construct(string $href, string $hreflang)
     {
         $this->href = $href;
         $this->hreflang = $hreflang;
     }
 
-    /**
-     * @return string
-     */
-    public function getHref()
+    public function getHref(): string
     {
         return $this->href;
     }
 
-    /**
-     * @return string
-     */
-    public function getHreflang()
+    public function getHreflang(): string
     {
         return $this->hreflang;
     }

--- a/Sitemap/SitemapIndex.php
+++ b/Sitemap/SitemapIndex.php
@@ -6,12 +6,9 @@ class SitemapIndex
     /**
      * @var SitemapSection
      */
-    private $sections;
+    private $sections = [];
 
-    /**
-     * @param SitemapSection $section
-     */
-    public function addSection(SitemapSection $section)
+    public function addSection(SitemapSection $section): void
     {
         $this->sections[] = $section;
     }
@@ -19,7 +16,7 @@ class SitemapIndex
     /**
      * @return SitemapSection[]
      */
-    public function getSections()
+    public function getSections(): array
     {
         return $this->sections;
     }

--- a/Sitemap/SitemapSection.php
+++ b/Sitemap/SitemapSection.php
@@ -13,34 +13,22 @@ class SitemapSection
      */
     private $pageCount = 0;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return int
-     */
-    public function getPageCount()
+    public function getPageCount(): int
     {
         return $this->pageCount;
     }
 
-    /**
-     * @param int $pageCount
-     */
-    public function setPageCount($pageCount)
+    public function setPageCount(int $pageCount): void
     {
         $this->pageCount = $pageCount;
     }

--- a/Sitemap/SitemapSectionPage.php
+++ b/Sitemap/SitemapSectionPage.php
@@ -8,33 +8,24 @@ class SitemapSectionPage
      * We keep the limit on 10000 to avoid having too big files that take too long to load
      * and make sure we don't hit reach the 50MB limit.
      */
-    const MAX_ITEMS_PER_PAGE = 10000;
+    public const MAX_ITEMS_PER_PAGE = 10000;
 
     /**
      * @var Url[]
      */
     private $urls = [];
 
-    /**
-     * @param Url $url
-     */
-    public function addUrl(Url $url)
+    public function addUrl(Url $url): void
     {
         $this->urls[] = $url;
     }
 
-    /**
-     * @return array
-     */
-    public function getUrls()
+    public function getUrls(): array
     {
         return $this->urls;
     }
 
-    /**
-     * @return int
-     */
-    public function getCount()
+    public function getCount(): int
     {
         return count($this->urls);
     }

--- a/Sitemap/Url.php
+++ b/Sitemap/Url.php
@@ -5,13 +5,13 @@ use DateTime;
 
 class Url
 {
-    const CHANGEFREQ_ALWAYS = 'always';
-    const CHANGEFREQ_HOURLY = 'hourly';
-    const CHANGEFREQ_DAILY = 'daily';
-    const CHANGEFREQ_WEEKLY = 'weekly';
-    const CHANGEFREQ_MONTHLY = 'monthly';
-    const CHANGEFREQ_YEARLY = 'yearly';
-    const CHANGEFREQ_NEVER = 'never';
+    public const CHANGEFREQ_ALWAYS = 'always';
+    public const CHANGEFREQ_HOURLY = 'hourly';
+    public const CHANGEFREQ_DAILY = 'daily';
+    public const CHANGEFREQ_WEEKLY = 'weekly';
+    public const CHANGEFREQ_MONTHLY = 'monthly';
+    public const CHANGEFREQ_YEARLY = 'yearly';
+    public const CHANGEFREQ_NEVER = 'never';
 
     /**
      * Absolute url
@@ -42,15 +42,7 @@ class Url
      */
     protected $alternateLinks;
 
-    /**
-     * Construct a new basic url
-     *
-     * @param string $loc - absolute url
-     * @param DateTime|null $lastmod
-     * @param string|null $changefreq
-     * @param float|null $priority
-     */
-    public function __construct($loc, $changefreq = null, $priority = null, DateTime $lastmod = null)
+    public function __construct(string $loc, ?string $changefreq = null, ?float $priority = null, ?DateTime $lastmod = null)
     {
         $this->setLoc($loc);
         $this->setLastmod($lastmod);
@@ -61,44 +53,27 @@ class Url
         }
     }
 
-    /**
-     * @param string $loc
-     */
-    protected function setLoc($loc)
+    protected function setLoc(string $loc): void
     {
         $this->loc = $loc;
     }
 
-    /**
-     * @return string
-     */
-    public function getLoc()
+    public function getLoc(): string
     {
         return $this->loc;
     }
 
-    /**
-     * @param DateTime|null $lastmod
-     */
-    protected function setLastmod(DateTime $lastmod = null)
+    protected function setLastmod(DateTime $lastmod = null): void
     {
         $this->lastmod = $lastmod;
     }
 
-    /**
-     * @return DateTime|null
-     */
-    public function getLastmod()
+    public function getLastmod(): ?DateTime
     {
         return $this->lastmod;
     }
 
-    /**
-     * Define the change frequency of this entry
-     *
-     * @param string|null $changefreq - String or null value used for defining the change frequency
-     */
-    protected function setChangefreq($changefreq = null)
+    protected function setChangefreq(string $changefreq = null): void
     {
         if (!in_array(
             $changefreq,
@@ -120,40 +95,26 @@ class Url
         $this->changefreq = $changefreq;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getChangefreq()
+    public function getChangefreq(): ?string
     {
         return $this->changefreq;
     }
 
-    /**
-     * Define the priority of this entry
-     *
-     * @param float $priority - Float or null value used for defining the priority
-     */
-    public function setPriority($priority)
+    public function setPriority(float $priority)
     {
-        if (is_numeric($priority) && $priority >= 0 && $priority <= 1) {
+        if ($priority >= 0 && $priority <= 1) {
             $this->priority = sprintf('%01.1f', $priority);
         } else {
             throw new \RuntimeException(sprintf('The value "%s" is not supported by the option priority, it must be a numeric between 0.0 and 1.0. See http://www.sitemaps.org/protocol.html#xmlTagDefinitions', $priority));
         }
     }
 
-    /**
-     * @return string|null
-     */
-    public function getPriority()
+    public function getPriority(): ?string
     {
         return $this->priority;
     }
 
-    /**
-     * @param AlternateLink $alternateLink
-     */
-    public function addAlternateLink(AlternateLink $alternateLink)
+    public function addAlternateLink(AlternateLink $alternateLink): void
     {
         $this->alternateLinks[] = $alternateLink;
     }
@@ -161,7 +122,7 @@ class Url
     /**
      * @return AlternateLink[]
      */
-    public function getAlternateLinks()
+    public function getAlternateLinks(): array
     {
         return $this->alternateLinks;
     }

--- a/Tests/Controller/GenerateControllerTest.php
+++ b/Tests/Controller/GenerateControllerTest.php
@@ -14,7 +14,7 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\Url;
 
 class GenerateControllerTest extends WebTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         $client = self::createClient();
         $url = $client->getContainer()->get('router')->generate(
@@ -51,7 +51,7 @@ class GenerateControllerTest extends WebTestCase
         $this->assertGreaterThan(0, $client->getResponse()->getTtl());
     }
 
-    public function testSectionAction()
+    public function testSectionAction(): void
     {
         $mockPage = 20;
         $mockSectionName = 'test';
@@ -96,7 +96,7 @@ class GenerateControllerTest extends WebTestCase
         $this->assertGreaterThan(0, $client->getResponse()->getMaxAge());
     }
 
-    public function testSectionActionWithAlternateLinks()
+    public function testSectionActionWithAlternateLinks(): void
     {
         $mockPage = 1;
         $mockSectionName = 'test';
@@ -145,7 +145,7 @@ class GenerateControllerTest extends WebTestCase
         $this->assertGreaterThan(0, $client->getResponse()->getMaxAge());
     }
 
-    public function testSectionActionOutOfRange()
+    public function testSectionActionOutOfRange(): void
     {
         $mockPage = 20;
         $mockSectionName = 'test';

--- a/Tests/Controller/app/AppKernel.php
+++ b/Tests/Controller/app/AppKernel.php
@@ -8,10 +8,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
  */
 class AppKernel extends Kernel
 {
-    /**
-     * @return array
-     */
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -20,10 +17,7 @@ class AppKernel extends Kernel
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config.yml');
     }

--- a/Tests/Controller/app/config.yml
+++ b/Tests/Controller/app/config.yml
@@ -1,7 +1,9 @@
 framework:
     secret:        test
-    router:        { resource: "%kernel.root_dir%/../../../Resources/config/routing.yml" }
-    templating:
-        engines: ['twig']
+    router:        { resource: "%kernel.project_dir%/Resources/config/routing.yml" }
     test: ~
     assets: ~
+
+twig:
+    paths:
+        '%kernel.project_dir%/Resources/views': WerkspotSitemapBundle

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -2,23 +2,24 @@
 namespace Werkspot\Bundle\SitemapBundle\Tests\Service;
 
 use Mockery;
+use PHPUnit\Framework\TestCase;
 use Werkspot\Bundle\SitemapBundle\Provider\ProviderInterface;
 use Werkspot\Bundle\SitemapBundle\Service\Generator;
 use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSection;
 
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * @var Generator
      */
     private $generator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new Generator;
     }
 
-    public function testGenerateIndexWithEmptyCount()
+    public function testGenerateIndexWithEmptyCount(): void
     {
         $mockProvider = Mockery::mock(ProviderInterface::class);
 
@@ -31,7 +32,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($index->getSections());
     }
 
-    public function testGenerateIndex()
+    public function testGenerateIndex(): void
     {
         $mockCount = 1234;
         $mockSection = Mockery::mock(SitemapSection::class);

--- a/Tests/SitemapSectionPageTest.php
+++ b/Tests/SitemapSectionPageTest.php
@@ -2,22 +2,26 @@
 namespace Werkspot\Bundle\SitemapBundle\Tests;
 
 use Mockery;
+use PHPUnit\Framework\TestCase;
 use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSectionPage;
 use Werkspot\Bundle\SitemapBundle\Sitemap\Url;
 
-class SitemapSectionPageTest extends \PHPUnit_Framework_TestCase
+class SitemapSectionPageTest extends TestCase
 {
     /**
      * @var SitemapSectionPage
      */
     protected $page;
 
-    protected function setUp()
+
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->page = new SitemapSectionPage();
     }
 
-    public function testGetUrls()
+    public function testGetUrls(): void
     {
         $mockUrl = Mockery::mock(Url::class);
         $this->assertEquals([], $this->page->getUrls());
@@ -25,7 +29,7 @@ class SitemapSectionPageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([$mockUrl], $this->page->getUrls());
     }
 
-    public function testCountUrls()
+    public function testCountUrls(): void
     {
         $mockUrl = Mockery::mock(Url::class);
         $this->assertEquals(0, $this->page->getCount());

--- a/composer.json
+++ b/composer.json
@@ -22,24 +22,24 @@
     },
     "authors": [
         {
-            "name": "Thanos Polymeneas",
-            "email": "zinbiel@gmail.com"
+            "name": "Werkspot Developers"
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/framework-bundle": "^4.1"
+        "php": "^7.2",
+        "symfony/framework-bundle": "^4.1 || ^5.1"
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "mockery/mockery": "^1.0@dev",
-        "phpunit/phpunit": "^5.7",
-        "symfony/finder": "^4.1",
-        "symfony/asset": "^4.1",
-        "symfony/templating": "^4.1",
-        "symfony/browser-kit": "^4.1",
-        "symfony/twig-bridge": "^4.1",
-        "symfony/twig-bundle": "^4.1"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^8.0",
+        "symfony/finder": "^4.1 || ^5.1",
+        "symfony/asset": "^4.1 || ^5.1",
+        "symfony/templating": "^4.1 || 5.1",
+        "symfony/browser-kit": "^4.1 || ^5.1",
+        "symfony/twig-bridge": "^4.1 || ^5.1",
+        "symfony/twig-bundle": "^4.1 || ^5.1",
+        "symfony/yaml": "^4.1 || ^5.1"
     },
     "config": {
         "bin-dir": "vendor/bin"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/framework-bundle": "^4.1"
     },
     "require-dev": {
+        "ext-simplexml": "*",
         "mockery/mockery": "^1.0@dev",
         "phpunit/phpunit": "^5.7",
         "symfony/finder": "^4.1",


### PR DESCRIPTION
Add support for Symfony 5.

Updating php's minimal requirement to 7.2 because that's what symfony 2 requires.

Also updating phpunit to 8.x, we could go to 9.x but that requires php 7.3, and keeping the requirement at 7.2 seems a better trade off.