### PR TITLE
Drop support for unsupported php and symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,11 @@ language: php
 dist: trusty
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
 
 env:
-  matrix:
-    - SYMFONY_VERSION="^4.4"
-
-matrix:
-  include:
-    - php: 7.2
-      env: SYMFONY_VERSION="^4.1"
-    - php: 7.2
-      env: SYMFONY_VERSION="^5.1"
-    - php: 7.4
-      env: SYMFONY_VERSION="^5.1"
+  - SYMFONY_VERSION="^4.4"
+  - SYMFONY_VERSION="^5.1"
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/Controller/GenerateController.php
+++ b/Controller/GenerateController.php
@@ -10,20 +10,11 @@ use Werkspot\Bundle\SitemapBundle\Service\Generator;
 
 final class GenerateController
 {
-    /**
-     * @var int
-     */
-    private $cacheAge;
+    private int $cacheAge;
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var Generator
-     */
-    private $sitemapGenerator;
+    private Generator $sitemapGenerator;
 
     public function __construct(int $cacheAge, Generator $sitemapGenerator, Environment $twig)
     {

--- a/Provider/AbstractSitemapProvider.php
+++ b/Provider/AbstractSitemapProvider.php
@@ -10,10 +10,7 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSectionPage;
 
 abstract class AbstractSitemapProvider implements ProviderInterface
 {
-    /**
-     * @var UrlGeneratorInterface
-     */
-    protected $urlGenerator;
+    protected UrlGeneratorInterface $urlGenerator;
 
     public function __construct(UrlGeneratorInterface $urlGenerator)
     {
@@ -22,7 +19,7 @@ abstract class AbstractSitemapProvider implements ProviderInterface
 
     final public function getNumberOfPages(): int
     {
-        return ceil($this->getCount() / $this->getMaxItemsPerPage());
+        return (int) ceil($this->getCount() / $this->getMaxItemsPerPage());
     }
 
     public function getSection(): SitemapSection
@@ -30,7 +27,7 @@ abstract class AbstractSitemapProvider implements ProviderInterface
         return new SitemapSection($this->getSectionName());
     }
 
-    final protected function generateUrl(strintg $routeName, array $options = []): string
+    final protected function generateUrl(string $routeName, array $options = []): string
     {
         return $this->urlGenerator->generate($routeName, $options, UrlGeneratorInterface::ABSOLUTE_URL);
     }

--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -14,7 +14,7 @@ class Generator
     /**
      * @var ProviderInterface[]
      */
-    private $providers = [];
+    private array $providers = [];
 
     public function generateIndex(): SitemapIndex
     {

--- a/Sitemap/AlternateLink.php
+++ b/Sitemap/AlternateLink.php
@@ -10,15 +10,9 @@ namespace Werkspot\Bundle\SitemapBundle\Sitemap;
  */
 class AlternateLink
 {
-    /**
-     * @var string
-     */
-    private $href;
+    private string $href;
 
-    /**
-     * @var string
-     */
-    private $hreflang;
+    private string $hreflang;
 
     public function __construct(string $href, string $hreflang)
     {

--- a/Sitemap/SitemapIndex.php
+++ b/Sitemap/SitemapIndex.php
@@ -9,7 +9,7 @@ class SitemapIndex
     /**
      * @var SitemapSection
      */
-    private $sections = [];
+    private array $sections = [];
 
     public function addSection(SitemapSection $section): void
     {

--- a/Sitemap/SitemapSection.php
+++ b/Sitemap/SitemapSection.php
@@ -6,15 +6,9 @@ namespace Werkspot\Bundle\SitemapBundle\Sitemap;
 
 class SitemapSection
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @var int
-     */
-    private $pageCount = 0;
+    private int $pageCount = 0;
 
     public function __construct(string $name)
     {

--- a/Sitemap/SitemapSectionPage.php
+++ b/Sitemap/SitemapSectionPage.php
@@ -16,7 +16,7 @@ class SitemapSectionPage
     /**
      * @var Url[]
      */
-    private $urls = [];
+    private array $urls = [];
 
     public function addUrl(Url $url): void
     {

--- a/Sitemap/Url.php
+++ b/Sitemap/Url.php
@@ -18,32 +18,22 @@ class Url
 
     /**
      * Absolute url
-     *
-     * @var string
      */
-    protected $loc;
+    protected string $loc;
 
-    /**
-     * @var DateTime|null
-     */
-    protected $lastmod;
+    protected ?DateTime $lastmod;
 
-    /**
-     * @var string|null
-     */
-    protected $changefreq;
+    protected ?string $changefreq;
 
     /**
      * String in float format
-     *
-     * @var string|null
      */
-    protected $priority;
+    protected ?string $priority;
 
     /**
      * @var AlternateLink[]
      */
-    protected $alternateLinks;
+    protected array $alternateLinks = [];
 
     public function __construct(string $loc, ?string $changefreq = null, ?float $priority = null, ?DateTime $lastmod = null)
     {

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -17,10 +17,7 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\SitemapSection;
  */
 final class GeneratorTest extends TestCase
 {
-    /**
-     * @var Generator
-     */
-    private $generator;
+    private Generator $generator;
 
     protected function setUp(): void
     {

--- a/Tests/SitemapSectionPageTest.php
+++ b/Tests/SitemapSectionPageTest.php
@@ -16,10 +16,7 @@ use Werkspot\Bundle\SitemapBundle\Sitemap\Url;
  */
 final class SitemapSectionPageTest extends TestCase
 {
-    /**
-     * @var SitemapSectionPage
-     */
-    protected $page;
+    protected SitemapSectionPage $page;
 
     protected function setUp(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -26,20 +26,20 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "symfony/framework-bundle": "^4.1 || ^5.1"
+        "php": "^7.4",
+        "symfony/framework-bundle": "^4.4 || ^5.1"
     },
     "require-dev": {
         "ext-simplexml": "*",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^4.1 || ^5.1",
-        "symfony/asset": "^4.1 || ^5.1",
-        "symfony/templating": "^4.1 || 5.1",
-        "symfony/browser-kit": "^4.1 || ^5.1",
-        "symfony/twig-bridge": "^4.1 || ^5.1",
-        "symfony/twig-bundle": "^4.1 || ^5.1",
-        "symfony/yaml": "^4.1 || ^5.1",
+        "phpunit/phpunit": "^9.0",
+        "symfony/finder": "^4.4 || ^5.1",
+        "symfony/asset": "^4.4 || ^5.1",
+        "symfony/templating": "^4.4 || 5.1",
+        "symfony/browser-kit": "^4.4 || ^5.1",
+        "symfony/twig-bridge": "^4.4 || ^5.1",
+        "symfony/twig-bundle": "^4.4 || ^5.1",
+        "symfony/yaml": "^4.4 || ^5.1",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "config": {


### PR DESCRIPTION
As discussed here: https://github.com/Werkspot/sitemap-bundle/pull/16#discussion_r462886347