### PR TITLE
Fix deprecation warning in php 8.4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1, 8.2]
-        symfony-version: ["^5.2", "^6.3"]
+        php-version: [8.3, 8.4]
+        symfony-version: ["6.4", "7.0", "7.1", "7.2"]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -32,10 +32,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           tools: composer
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: composer install
       - name: Run CS fixer
-        run: vendor/bin/php-cs-fixer fix --dry-run
+        run: PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ language: php
 dist: bionic
 
 php:
-  - 7.4
-  - 8.0
-  - 8.1
-  - 8.2
+  - 8.3
+  - 8.4
 
 env:
-  - SYMFONY_VERSION="^4.4"
-  - SYMFONY_VERSION="^5.2"
-  - SYMFONY_VERSION="^6.3"
+  - SYMFONY_VERSION="^6.4"
+  - SYMFONY_VERSION="^7.0"
+  - SYMFONY_VERSION="^7.1"
+  - SYMFONY_VERSION="^7.2"
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/Controller/GenerateController.php
+++ b/Controller/GenerateController.php
@@ -8,22 +8,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Werkspot\Bundle\SitemapBundle\Service\Generator;
 
-final class GenerateController
+final readonly class GenerateController
 {
-    private int $cacheAge;
-
-    private Environment $twig;
-
-    private Generator $sitemapGenerator;
-
     public function __construct(
-        int $cacheAge,
-        Generator $sitemapGenerator,
-        Environment $twig,
+        private int $cacheAge,
+        private Generator $sitemapGenerator,
+        private Environment $twig,
     ) {
-        $this->cacheAge = $cacheAge;
-        $this->twig = $twig;
-        $this->sitemapGenerator = $sitemapGenerator;
     }
 
     /** Shows the sitemap index with links to deeper sitemap sections */
@@ -57,7 +48,7 @@ final class GenerateController
         return $response;
     }
 
-    private function render(string $view, array $parameters = [], Response $response = null): Response
+    private function render(string $view, array $parameters = [], ?Response $response = null): Response
     {
         $content = $this->twig->render($view, $parameters);
 

--- a/Sitemap/Url.php
+++ b/Sitemap/Url.php
@@ -7,6 +7,7 @@ namespace Werkspot\Bundle\SitemapBundle\Sitemap;
 use DateTime;
 use RuntimeException;
 use function in_array;
+use function sprintf;
 
 class Url
 {

--- a/composer.json
+++ b/composer.json
@@ -26,21 +26,21 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0"
+        "php": "^8.3",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^7.1 || ^7.2"
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^9.5",
-        "symfony/finder": "^5.4 || ^6.4 || ^7.0",
-        "symfony/asset": "^5.4 || ^6.4 || ^7.0",
-        "symfony/templating": "^5.4 || ^6.4 || ^7.0",
-        "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0",
-        "symfony/twig-bridge": "^5.4 || ^6.4 || ^7.0",
-        "symfony/twig-bundle": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
-        "instapro/coding-standard": "^1.0"
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^9.6",
+        "symfony/finder": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/asset": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/templating": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/twig-bridge": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/twig-bundle": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "symfony/yaml": "^6.4 || ^7.0 || ^7.1 || ^7.2",
+        "instapro/coding-standard": "^1.2"
     },
     "config": {
         "bin-dir": "vendor/bin"


### PR DESCRIPTION
When an argument has a default value of null the type has to be nullable as well.